### PR TITLE
Remove tflite-runtime, add pyyaml dependency, and update test imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ requires-python = ">=3.8"
 dependencies = [
     "numpy>=1.21.0",
     "onnx>=1.12.0",
-    "tflite-runtime>=2.13.0",
     "psutil>=5.8.0",
     "click>=8.0.0",
     "pydantic>=1.9.0",
@@ -42,7 +41,8 @@ dependencies = [
     "matplotlib>=3.5.0",
     "plotly>=5.0.0",
     "pandas>=1.4.0",
-    "requests>=2.28.0"
+    "requests>=2.28.0",
+    "pyyaml>=5.1"
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 import sys
 import os
+from typing import Dict, Any, Generator
 
 # Add src directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))


### PR DESCRIPTION
## Summary
- Removed `tflite-runtime` dependency from `pyproject.toml`
- Added `pyyaml` as a new dependency in `pyproject.toml`
- Updated `tests/conftest.py` to include typing imports for better type hinting

## Changes

### Dependency Updates
- Removed `tflite-runtime>=2.13.0` from the dependencies list
- Added `pyyaml>=5.1` to the dependencies list

### Test Configuration
- Imported `Dict`, `Any`, and `Generator` from `typing` in `tests/conftest.py` to improve type annotations

## Test plan
- Ensure all existing tests pass without the `tflite-runtime` dependency
- Verify that the new `pyyaml` dependency is correctly installed and usable
- Confirm no import errors in test setup due to typing additions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b2abd2a1-c28f-48c4-a860-e4aa5cd38eb6